### PR TITLE
Add `.log` to log observable changes

### DIFF
--- a/async/async.js
+++ b/async/async.js
@@ -1,5 +1,3 @@
-var canReflect = require('can-reflect');
-var ObservationRecorder = require('can-observation-recorder');
 var SimpleObservable = require("../can-simple-observable");
 var Observation = require("can-observation");
 var KeyTree = require('can-key-tree');
@@ -21,9 +19,17 @@ function AsyncObservable(fn, context, initialValue) {
 	this.handler = this.handler.bind(this);
 }
 AsyncObservable.prototype = Object.create(SettableObservable.prototype);
+AsyncObservable.prototype.constructor = AsyncObservable;
 AsyncObservable.prototype.resolve = function resolve(newVal) {
 	var old = this.value;
 	this.value = newVal;
+
+	//!steal-remove-start
+	if (typeof this._log === "function") {
+		this._log(old, newVal);
+	}
+	//!steal-remove-end
+
 	// adds callback handlers to be called w/i their respective queue.
 	queues.enqueueByQueue(this.handlers.getNode([]), this, [newVal, old], function() {
 		return {};

--- a/can-simple-observable-test.js
+++ b/can-simple-observable-test.js
@@ -32,3 +32,20 @@ QUnit.test('basics', function(){
 
     QUnit.equal(canReflect.getValue(obs), 'four', 'getValue after offValue');
 });
+
+QUnit.test("log observable changes", function(assert) {
+	var done = assert.async();
+	var obs = new SimpleObservable("one");
+
+	// turn on debugging
+	obs.log();
+
+	assert.expect(2);
+	obs._log = function(previous, current) {
+		assert.equal(current, "two", "should get current value");
+		assert.equal(previous, "one", "should get previous value");
+		done();
+	};
+
+	canReflect.setValue(obs, "two");
+});

--- a/can-simple-observable.js
+++ b/can-simple-observable.js
@@ -3,6 +3,7 @@ var ObservationRecorder = require('can-observation-recorder');
 var ns = require('can-namespace');
 var KeyTree = require('can-key-tree');
 var queues = require("can-queues");
+var log = require("./log");
 
 function makeMeta(handler, context, args) {
 	return {
@@ -61,6 +62,11 @@ SimpleObservable.prototype = {
 		this.value = value;
 		// adds callback handlers to be called w/i their respective queue.
 		queues.enqueueByQueue(this.handlers.getNode([]), this, [value, old], makeMeta);
+		//!steal-remove-start
+		if (typeof this._log === "function") {
+			this._log(old, value);
+		}
+		//!steal-remove-end
 	},
 	// .on( handler(newValue,oldValue), queue="mutate")
 	on: function(handler, queue){
@@ -68,7 +74,8 @@ SimpleObservable.prototype = {
 	},
 	off: function(handler, queue){
 		this.handlers.delete([queue|| "mutate", handler]);
-	}
+	},
+	log: log
 };
 
 canReflect.assignSymbols(SimpleObservable.prototype,{

--- a/log.js
+++ b/log.js
@@ -1,0 +1,25 @@
+var dev = require("can-log/dev/dev");
+var canReflect = require("can-reflect");
+
+// when printing out strings to the console, quotes are not included which
+// makes it confusing to tell the actual output from static string messages
+function quoteString(x) {
+	return typeof x === "string" ? JSON.stringify(x) : x;
+}
+
+// To add the `.log` function to a observable
+// a.- Add the log function to the propotype:
+//	   `Observable.propotype.log = log`
+// b.- Make sure `._log` is called by the observable when mutation happens
+//     `_.log` should be passed the current value and the value before the mutation
+module.exports = function log() {
+	//!steal-remove-start
+	this._log = function(previous, current) {
+		dev.log(
+			canReflect.getName(this),
+			"\n is  ", quoteString(current),
+			"\n was ", quoteString(previous)
+		);
+	};
+	//!steal-remove-end
+};

--- a/package.json
+++ b/package.json
@@ -38,11 +38,12 @@
   },
   "dependencies": {
     "can-key-tree": "0.X",
+    "can-log": "^0.1.0",
     "can-namespace": "1.0.0",
     "can-observation": "^4.0.0-pre.1",
     "can-observation-recorder": "<2.0.0",
     "can-queues": "<2.0.0",
-    "can-reflect": "^1.6.0"
+    "can-reflect": "^1.7.0"
   },
   "devDependencies": {
     "detect-cyclic-packages": "^1.1.0",

--- a/settable/settable.js
+++ b/settable/settable.js
@@ -4,6 +4,7 @@ var SimpleObservable = require("../can-simple-observable");
 var Observation = require("can-observation");
 var KeyTree = require('can-key-tree');
 var queues = require("can-queues");
+var log = require("../log");
 
 // This supports an "internal" settable value that the `fn` can derive its value from.
 // It's useful to `can-define`.
@@ -30,6 +31,13 @@ SettableObservable.prototype = {
 	handler: function(newVal) {
 		var old = this.value;
 		this.value = newVal;
+
+		//!steal-remove-start
+		if (typeof this._log === "function") {
+			this._log(old, newVal);
+		}
+		//!steal-remove-end
+
 		// adds callback handlers to be called w/i their respective queue.
 		queues.enqueueByQueue(this.handlers.getNode([]), this, [newVal, old], function() {
 			return {};
@@ -71,8 +79,14 @@ SettableObservable.prototype = {
 	},
 	hasDependencies: function(){
 		return canReflect.valueHasDependencies( this.observation );
-	}
+	},
+	// call `obs.log()` to log observable changes to the browser console
+	// The observable has to be bound for `.log` to be called
+	log: log
 };
+
+// fix the constructor reference
+SettableObservable.prototype.constructor = SettableObservable;
 
 canReflect.assignSymbols(SettableObservable.prototype, {
 	"can.getValue": SettableObservable.prototype.get,

--- a/setter/setter-test.js
+++ b/setter/setter-test.js
@@ -2,7 +2,6 @@ var QUnit = require('steal-qunit');
 var SetterObservable = require('./setter');
 var SimpleObservable = require('../can-simple-observable');
 var canReflect = require('can-reflect');
-var ObservationRecorder = require("can-observation-recorder");
 
 QUnit.module('can-simple-observable/setter');
 
@@ -38,4 +37,38 @@ QUnit.test("get and set Priority", function(){
 
 
     QUnit.equal(canReflect.getPriority(obs), 5, "set priority");
+});
+
+QUnit.test("log observable changes", function(assert) {
+	var done = assert.async();
+	var value = new SimpleObservable(2);
+
+	var obs = new SetterObservable(function() {
+		return value.get();
+	}, function(newVal){
+		value.set(newVal);
+	});
+
+	// turn on logging
+	obs.log();
+
+	// override _log to spy on arguments
+	var changes = [];
+	obs._log = function(previous, current) {
+		changes.push({ current: current, previous: previous });
+	};
+
+	canReflect.onValue(obs, function() {}); // needs to be bound
+	canReflect.setValue(obs, 3);
+	canReflect.setValue(obs, 4);
+
+	assert.expect(1);
+	setTimeout(function() {
+		assert.deepEqual(
+			changes,
+			[{current: 3, previous: 2}, {current: 4, previous: 3}],
+			"should print out current/previous values"
+		);
+		done();
+	});
 });

--- a/setter/setter.js
+++ b/setter/setter.js
@@ -1,9 +1,6 @@
 var canReflect = require('can-reflect');
-var ObservationRecorder = require('can-observation-recorder');
-var SimpleObservable = require("../can-simple-observable");
 var Observation = require("can-observation");
 var KeyTree = require('can-key-tree');
-var queues = require("can-queues");
 var SettableObservable = require("../settable/settable");
 
 // SetterObservable's call a function when set. Their getter is backed up by an
@@ -13,7 +10,7 @@ function SetterObservable(getter, setter) {
 		onFirst: this.setup.bind(this),
 		onEmpty: this.teardown.bind(this)
 	});
-    this.setter = setter;
+	this.setter = setter;
 	this.observation = new Observation(getter);
 	this.handler = this.handler.bind(this);
 }


### PR DESCRIPTION
Before I go ahead and write actual tests/docs for this @justinbmeyer 

a) do you have any feedback? 
b) Since the default output might not be optimal for everyone, what if we make it so you users can provide the spy handlers? 

```js
var obs = new SimpleObservable('one');

obs.spy(function(name, old, current) {
  console.table([ {name, old, current } ]);
});
```
do you want me to do this? I'll have to add support for this signature: `obs.spy(name?, handler?)` (vs the current one which is `obs.spy(name?)`. 

//// @christopherjbaker 

I know you'll eventually work on this repo too, question: is this change going to affect your stuff somehow? anything I can do so this changes don't make your life harder? =)


----
The custom output with `console.table`; we can debate whether it's useful output but the fact that I can do it it's pretty cool.

![screen shot 2017-10-13 at 14 37 24](https://user-images.githubusercontent.com/724877/31565589-9028fa0c-b024-11e7-9ef6-4a6a43abe368.png)
