### PR TITLE
Add KeyObservable

### DIFF
--- a/key/key-test.js
+++ b/key/key-test.js
@@ -1,0 +1,25 @@
+var QUnit = require("steal-qunit");
+var KeyObservable = require("./key");
+var canReflect = require("can-reflect");
+
+QUnit.module("can-simple-observable/key");
+
+QUnit.test("basics", function(assert) {
+    var value = {foo: {bar: "baz"}};
+    var obs = new KeyObservable(value, "foo.bar");
+
+    // Unbound and unobserved behavior
+    assert.equal(canReflect.getValue(obs), "baz", "getValue unbound");
+
+    canReflect.setValue(obs, "new");
+    assert.equal(canReflect.getValue(value).foo.bar, "new", "value set");
+    assert.equal(canReflect.getValue(obs), "new", "getValue unbound");
+});
+
+QUnit.test("get and set Priority", function(assert) {
+    var value = {foo: {bar: "baz"}};
+    var obs = new KeyObservable(value, "foo.bar");
+
+    canReflect.setPriority(obs, 5);
+    assert.equal(canReflect.getPriority(obs), 5, "set priority");
+});

--- a/key/key.js
+++ b/key/key.js
@@ -1,0 +1,25 @@
+var canKey = require("can-key");
+var canReflect = require("can-reflect");
+var Observation = require("can-observation");
+var SettableObservable = require("../settable/settable");
+
+function KeyObservable(root, keyPath) {
+	keyPath = "" + keyPath;
+	this._keyPath = keyPath;
+	this._root = root;
+
+	SettableObservable.call(this, function() {
+		return canKey.get(root, keyPath);
+	}, root);
+}
+
+KeyObservable.prototype = Object.create(SettableObservable.prototype);
+KeyObservable.prototype.constructor = KeyObservable;
+KeyObservable.prototype.set = function(newVal) {
+	canKey.set(this._root, this._keyPath, newVal);
+};
+canReflect.assignSymbols(KeyObservable.prototype, {
+	"can.setValue": KeyObservable.prototype.set
+});
+
+module.exports = KeyObservable;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "can-event-queue": "^1.0.0",
+    "can-key": "<2.0.0",
     "can-key-tree": "^1.0.0",
     "can-log": "^1.0.0",
     "can-namespace": "1.0.0",

--- a/test.js
+++ b/test.js
@@ -2,5 +2,6 @@ require("./can-simple-observable-test");
 require("./settable/settable-test");
 require("./async/async-test");
 require("./setter/setter-test");
+require("./key/key-test");
 require("./make-compute/make-compute-test");
 require("./resolver/resolver-test");


### PR DESCRIPTION
I didn’t include docs because the other modules in this package aren’t publicly documented.

Closes https://github.com/canjs/can-simple-observable/issues/22