### PR TITLE
Remove debug data from the key module in production builds

### DIFF
--- a/key/key-test.js
+++ b/key/key-test.js
@@ -4,6 +4,8 @@ var canReflect = require("can-reflect");
 var canReflectDeps = require("can-reflect-dependencies");
 var SimpleMap = require("can-simple-map");
 
+var onlyDevTest = steal.isEnv("production") ? QUnit.skip : QUnit.test;
+
 QUnit.module("can-simple-observable/key");
 
 QUnit.test("basics", function(assert) {
@@ -26,7 +28,7 @@ QUnit.test("get and set Priority", function(assert) {
 	assert.equal(canReflect.getPriority(observable), 5, "set priority");
 });
 
-QUnit.test("observable has a helpful name", function() {
+onlyDevTest("observable has a helpful name", function() {
 	var outer = {inner: {key: "hello"}};
 	var observable = keyObservable(outer, "inner.key");
 	QUnit.equal(
@@ -36,7 +38,7 @@ QUnit.test("observable has a helpful name", function() {
 	);
 });
 
-QUnit.test("dependency data", function(assert) {
+onlyDevTest("dependency data", function(assert) {
 	var outer = new SimpleMap({inner: new SimpleMap({key: "hello"})});
 	var observable = keyObservable(outer, "inner.key");
 
@@ -118,15 +120,25 @@ QUnit.test("works when the keys change", function(assert) {
 	// Test initial value
 	assert.equal(canReflect.getValue(observable), "hello", "initial value is correct");
 
-	// The observable must be bound before it returns dependency data
-	canReflect.onValue(observable, function() {});
-
 	// Change the value of a key along the path
 	var newInner = new SimpleMap({key: "aloha"});
 	outer.set("inner", newInner);
 
 	// Check that the observable has the new value
 	assert.equal(canReflect.getValue(observable), "aloha", "observable updated");
+});
+
+onlyDevTest("works when the keys change - dependency data", function(assert) {
+	var originalInner = new SimpleMap({key: "hello"});
+	var outer = new SimpleMap({inner: originalInner});
+	var observable = keyObservable(outer, "inner.key");
+
+	// The observable must be bound before it returns dependency data
+	canReflect.onValue(observable, function() {});
+
+	// Change the value of a key along the path
+	var newInner = new SimpleMap({key: "aloha"});
+	outer.set("inner", newInner);
 
 	// Check the observable’s dependency data
 	var observableDepData = canReflectDeps.getDependencyDataOf(observable);

--- a/key/key.js
+++ b/key/key.js
@@ -6,9 +6,13 @@ var Observation = require("can-observation");
 
 module.exports = function keyObservable(root, keyPath) {
 	var keyPathParts = canKeyUtils.parts(keyPath);
+
+	// Some variables used to build the dependency/mutation graph
+	//!steal-remove-start
 	var lastIndex = keyPathParts.length - 1;
 	var lastKey;// This stores the last part of the keyPath, e.g. “key” in “outer.inner.key”
 	var lastParent;// This stores the object that the last key is on, e.g. “outer.inner” in outer: {inner: {"key": "value"}}
+	//!steal-remove-end
 
 	var observation = new Observation(function() {
 		var value;
@@ -16,6 +20,7 @@ module.exports = function keyObservable(root, keyPath) {
 		// This needs to be walked every time because the objects along the key path might change
 		canKey.walk(root, keyPathParts, function(keyData, i) {
 			if (i === lastIndex) {
+				//!steal-remove-start
 				// observation is mutating keyData.parent
 				if (lastParent && (keyData.key !== lastKey || keyData.parent !== lastParent)) {
 					canReflectDependencies.deleteMutatedBy(lastParent, lastKey, observation);
@@ -23,6 +28,8 @@ module.exports = function keyObservable(root, keyPath) {
 				lastKey = keyData.key;
 				lastParent = keyData.parent;
 				canReflectDependencies.addMutatedBy(lastParent, lastKey, observation);
+				//!steal-remove-end
+
 				value = keyData.value;
 			}
 		});
@@ -31,12 +38,15 @@ module.exports = function keyObservable(root, keyPath) {
 	});
 
 	return canReflect.assignSymbols(observation, {
+		//!steal-remove-start
 		"can.getName": function getName() {
 			var objectName = canReflect.getName(root);
 			return "keyObservable<" + objectName + "." + keyPath + ">";
 		},
+		//!steal-remove-end
 
 		// Register what this observable changes
+		//!steal-remove-start
 		"can.getWhatIChange": function getWhatIChange() {
 			return {
 				mutate: {
@@ -46,6 +56,7 @@ module.exports = function keyObservable(root, keyPath) {
 				}
 			};
 		},
+		//!steal-remove-end
 
 		"can.setValue": function(newVal) {
 			canKey.set(root, keyPathParts, newVal);


### PR DESCRIPTION
This wraps the code used for debug data (including dependencies/mutations) with `steal-remove-start` and `steal-remove-end` so it’s not included in production builds.

This also updates the tests to only test those things in dev builds.