### PR TITLE
Add a value property getter & setter to the key module/observable

### DIFF
--- a/key/key-test.js
+++ b/key/key-test.js
@@ -20,6 +20,19 @@ QUnit.test("basics", function(assert) {
 	assert.equal(canReflect.getValue(observable), "aloha", "getValue unbound");
 });
 
+QUnit.test("value property is a getter and setter", function(assert) {
+	var outer = {inner: {key: "hello"}};
+	var observable = keyObservable(outer, "inner.key");
+
+	// Check getting the value
+	assert.equal(observable.value, "hello", "value getter works");
+
+	// Check setting the value
+	observable.value = "aloha";
+	assert.equal(canReflect.getValue(outer).inner.key, "aloha", "value setter sets other object");
+	assert.equal(canReflect.getValue(observable), "aloha", "value getter works after set");
+});
+
 QUnit.test("get and set Priority", function(assert) {
 	var outer = {inner: {key: "hello"}};
 	var observable = keyObservable(outer, "inner.key");

--- a/key/key.js
+++ b/key/key.js
@@ -46,10 +46,19 @@ module.exports = function keyObservable(root, keyPath) {
 		return value;
 	});
 
+	// Function for setting the value
+	var valueSetter = function(newVal) {
+		canKey.set(root, keyPathParts, newVal);
+	};
+
+	// The `value` property getter & setter
+	Object.defineProperty(observation, "value", {
+		get: observation.get,
+		set: valueSetter
+	});
+
 	var symbolsToAssign = {
-		"can.setValue": function(newVal) {
-			canKey.set(root, keyPathParts, newVal);
-		}
+		"can.setValue": valueSetter
 	};
 
 	//!steal-remove-start

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "can-key-tree": "^1.0.0",
     "can-log": "^1.0.0",
     "can-namespace": "1.0.0",
-    "can-observation": "^4.0.0",
+    "can-observation": "^4.1.0",
     "can-observation-recorder": "^1.0.0",
     "can-queues": "^1.0.0",
     "can-reflect": "^1.10.1",


### PR DESCRIPTION
This adds an API for getting & setting the value of the observation returned by the key module:

```js
import keyObservable from "can-simple-observable/key/key";

const outer = {inner: {key: "hello"}};
const observable = keyObservable(outer, "inner.key");

observable.value; // is "hello"

observable.value = "goodbye";
observable.value; // is now "goodbye"
```

This PR doesn’t include docs because there are no docs for the key module (it’s used by can-value and will be mentioned there).

Related to https://github.com/canjs/can-observation/issues/130